### PR TITLE
avformat,avutl/Makefile: move some headers to install include dir

### DIFF
--- a/libavformat/Makefile
+++ b/libavformat/Makefile
@@ -4,6 +4,16 @@ DESC = FFmpeg container format library
 HEADERS = avformat.h                                                    \
           avio.h                                                        \
           version.h                                                     \
+		  avc.h                                                         \
+		  hevc.h                                                         \
+          url.h                                                         \
+          internal.h                                                    \
+          avio_internal.h                                               \
+          metadata.h                                                    \
+          id3v2.h                                                       \
+          flv.h                                                         \
+          os_support.h
+
 
 OBJS = allformats.o         \
        avio.o               \

--- a/libavutil/Makefile
+++ b/libavutil/Makefile
@@ -73,6 +73,7 @@ HEADERS = adler32.h                                                     \
           sha512.h                                                      \
           spherical.h                                                   \
           stereo3d.h                                                    \
+          thread.h                                                    \
           threadmessage.h                                               \
           time.h                                                        \
           timecode.h                                                    \


### PR DESCRIPTION
some function is needed by slot modules,
do install headers to include dir:
avc.h
hevc.h
url.h
internal.h
avio_internal.h
metadata.h
id3v2.h
flv.h
os_support.h